### PR TITLE
chore(CI): Updates image tag assignments for image builds (#27)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -76,6 +76,20 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Set amd64 Image Tags
+        id: image-tags
+        if: matrix.platform == 'amd64'
+        run: |
+          IMAGE_TAGS=$(echo php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }},php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }}-${{ matrix.platform }})
+          echo "IMAGE_TAGS=$IMAGE_TAGS" >> $GITHUB_OUTPUT
+
+      - name: Set arm64 Image Tags
+        id: image-tags
+        if: matrix.platform == 'arm64'
+        run: |
+          IMAGE_TAGS=$(echo php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }}-${{ matrix.platform }})
+          echo "IMAGE_TAGS=$IMAGE_TAGS" >> $GITHUB_OUTPUT
+
       # https://github.com/marketplace/actions/dev-container-build-and-run-action
       - name: Pre-build Dev Container Image
         uses: devcontainers/ci@v0.3
@@ -88,7 +102,7 @@ jobs:
           platform: linux/${{ matrix.platform }}
           imageName: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PACKAGE }}
           cacheFrom: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PACKAGE }}
-          imageTag: php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }},php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }}-${{ matrix.platform }}
+          imageTag: ${{ steps.image-tags.outputs.IMAGE_TAGS }}
           push: always
           skipContainerUserIdUpdate: true
 
@@ -146,7 +160,6 @@ jobs:
       - name: Create Manifest List and Push
         run: |
             docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PACKAGE }}:php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }} \
-            --append ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PACKAGE }}:php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }}-amd64 \
             --append ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.PACKAGE }}:php-${{ matrix.PHP_VERSION }}-node-${{ matrix.NODE_VERSION }}-arm64
 
       - name: Inspect Manifest List


### PR DESCRIPTION
- Changes the tags assigned to the image builds based on platform to ensure final manifest only contains 2 platform digests.