### PR TITLE
fix(deps): Changes testing builds to no longer test EOL versions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       matrix: 
         PHP_VERSION:
-          - '8.0'
+          - '8.1'
           - '8.3'
         NODE_VERSION:
-          - '16'
+          - '18'
           - '20'
         builder:
           - ubuntu-22.04


### PR DESCRIPTION
- Updates the testing GitHub Actions workflow to no longer test EOL versions of PHP & NodeJS.
