### PR TITLE
2024-02-16 PHP & NodeJS Updates Release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -201,7 +201,7 @@ jobs:
 
       # https://github.com/marketplace/actions/create-release
       - name: Create Release
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@v1.14.0
         with:
           name: ${{ steps.release-name.outputs.RELEASE_NAME }}
           tag: ${{ steps.semver.outputs.next }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       matrix: 
         PHP_VERSION:
-          - '8.0'
+          - '8.1'
           - '8.3'
         NODE_VERSION:
-          - '16'
+          - '18'
           - '20'
         builder:
           - ubuntu-22.04


### PR DESCRIPTION
- chore(deps): update ncipollo/release-action action to v1.14.0 (#41)
- fix(deps): Changes testing builds to no longer test EOL versions (#42)
