### PR TITLE
fix(GHA Releases): Fixes missing PHP 8.0 Releases Removal

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix: 
         PHP_VERSION:
-          - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'


### PR DESCRIPTION
- Properly removes PHP 8.0 builds from the final releases GHA workflow.
