### PR TITLE
2026-01-26 Features Release

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_VERSION=8.3
 
-FROM php:${PHP_VERSION}-fpm-bullseye
+FROM php:${PHP_VERSION}-fpm-bookworm
 
 LABEL org.opencontainers.image.url=https://github.com/ndigitals/wp-dev-container/pkgs/container/wp-dev-container
 LABEL org.opencontainers.image.documentation=https://github.com/ndigitals/wp-dev-container/wiki
@@ -15,15 +15,15 @@ WORKDIR /var/www
 # This setup is generally a direct copy from https://github.com/WordPress/wpdev-docker-images
 #
 
-ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV COMPOSER_HOME /tmp
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_HOME=/tmp
 
 # install the PHP extensions we need
 RUN set -ex; \
 	\
 	apt-get update; \
 	\
-	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync libxslt-dev git; \
+	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libssl-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync libxslt-dev git; \
 	apt-get upgrade openssl -y; \
 	update-ca-certificates --fresh; \
 	sed -i 's/^# *\(\(ru_RU\|fr_FR\|de_DE\|es_ES\|ja_JP\).UTF-8\)/\1/' /etc/locale.gen; \
@@ -31,13 +31,15 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install opcache || true; \
+	\
+	docker-php-ext-install gd mysqli zip exif intl mbstring xml xsl; \
 	\
 	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \
 	chmod +x /usr/local/bin/pickle; \
 	\
-	pickle install memcached-3.2.0; \
-	pickle install xdebug-3.3.0; \
+	pickle install memcached-3.4.0; \
+	pickle install xdebug-3.5.0; \
 	pickle install imagick; \
 	docker-php-ext-enable imagick; \
 	\

--- a/.devcontainer/common.sh
+++ b/.devcontainer/common.sh
@@ -6,7 +6,7 @@ if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 else
-	docker-php-ext-enable opcache
+	docker-php-ext-enable opcache || true
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 fi
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix: 
         PHP_VERSION:
-          - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,11 +29,13 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         NODE_VERSION:
           - '16'
           - '18'
           - '20'
           - '22'
+          - '24'
         builder:
           - ubuntu-22.04
           - self-hosted
@@ -54,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
 
@@ -73,7 +75,7 @@ jobs:
 
       # https://github.com/marketplace/actions/setup-node-js-environment
       - name: Setup Node Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -205,7 +207,7 @@ jobs:
 
       # https://github.com/marketplace/actions/create-release
       - name: Create Release
-        uses: ncipollo/release-action@v1.16.0
+        uses: ncipollo/release-action@v1.20.0
         if: github.event_name == 'push'
         with:
           name: ${{ steps.release-name.outputs.RELEASE_NAME }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -24,10 +24,10 @@ jobs:
       matrix: 
         PHP_VERSION:
           - '8.1'
-          - '8.3'
+          - '8.4'
         NODE_VERSION:
           - '18'
-          - '22'
+          - '24'
         builder:
           - ubuntu-22.04
           - self-hosted
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
 
@@ -64,7 +64,7 @@ jobs:
 
       # https://github.com/marketplace/actions/setup-node-js-environment
       - name: Setup Node Environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ WordPress Plugin &amp; Theme Dev Container
 
 ## Supported tags
 
-- `php-8.3-node-22`, `php-8.3-node-20`, `php-8.3-node-18`, `php-8.3-node-16`
-- `php-8.2-node-22`, `php-8.2-node-20`, `php-8.2-node-18`, `php-8.2-node-16`
-- `php-8.1-node-22`, `php-8.1-node-20`, `php-8.1-node-18`, `php-8.1-node-16`
-- `php-8.0-node-22`, `php-8.0-node-20`, `php-8.0-node-18`, `php-8.0-node-16`
+- `php-8.4-node-24`, `php-8.4-node-22`, `php-8.4-node-20`, `php-8.4-node-18`, `php-8.4-node-16`
+- `php-8.3-node-24`, `php-8.3-node-22`, `php-8.3-node-20`, `php-8.3-node-18`, `php-8.3-node-16`
+- `php-8.2-node-24`, `php-8.2-node-22`, `php-8.2-node-20`, `php-8.2-node-18`, `php-8.2-node-16`
+- `php-8.1-node-24`, `php-8.1-node-22`, `php-8.1-node-20`, `php-8.1-node-18`, `php-8.1-node-16`
 
 ## Prerequisites
 


### PR DESCRIPTION
- feat: Adds additional PHP & NodeJS versions (#59)
  - Adds support for PHP 8.4.
    - Adds proactive handling for opcache default on for PHP 8.5.
    - Memcache is not currently supported in PHP 8.5 so it will not be supported at this time.
  - Installs libssl-dev for PHP memcache extension support.
    - Updates to memcached 3.4.0
  - Updates to xdebug 3.5.0, for newer PHP support.
  - Drops support for PHP 8.0.
  - Adds support for NodeJS 24.
  - Updates GA dependencies.
- fix(GHA Releases): Fixes missing PHP 8.0 Releases Removal (#61)
